### PR TITLE
Fix Classic Era 1.15.9 quest tracker backdrop

### DIFF
--- a/ModernQuestWatch.lua
+++ b/ModernQuestWatch.lua
@@ -106,6 +106,10 @@ function MQW:Initialize()
 	AnchorFrame:SetSize(1, 1)
 	QuestWatchFrame:SetMovable(true)
 	QuestWatchFrame:SetClampedToScreen(true)
+	if not QuestWatchFrame.SetBackdrop and BackdropTemplateMixin then
+		Mixin(QuestWatchFrame, BackdropTemplateMixin)
+		QuestWatchFrame:OnBackdropLoaded()
+	end
 	QuestWatchFrame:SetBackdrop({bgFile = "Interface/Tooltips/UI-Tooltip-Background"})
 	QuestWatchFrame:SetBackdropColor(0, 0, 0, 0)
 	QuestWatchFrame:RegisterForDrag("LeftButton")

--- a/ModernQuestWatch.toc
+++ b/ModernQuestWatch.toc
@@ -1,4 +1,4 @@
-## Interface: 11302
+## Interface: 11509
 ## Version: @project-version@
 ## Title: Modern Quest Watch
 ## Notes: Improves the Quest Tracker


### PR DESCRIPTION
## Summary

- initialize `BackdropTemplateMixin` on `QuestWatchFrame` before using backdrop methods
- keep the existing drag highlight and positioning behavior unchanged
- bump the Classic Era interface version to `11509`

## Problem

On Classic Era 1.15.9, `QuestWatchFrame` no longer exposes `SetBackdrop` by default. `ModernQuestWatch:Initialize()` therefore fails at startup with:

```
attempt to call a nil value
ModernQuestWatch.lua:109: in function 'Initialize'
```

The guarded mixin initialization restores the backdrop methods only when they are missing and the mixin is available.

## Verification

- the mixin is applied before the existing `SetBackdrop` call
- the change is guarded for clients where the method already exists
- `git diff --check` passes
- the PR contains one commit and changes only `ModernQuestWatch.lua` and `ModernQuestWatch.toc`